### PR TITLE
additional optional parameters for meta git clone

### DIFF
--- a/bin/meta-git-clone
+++ b/bin/meta-git-clone
@@ -7,9 +7,21 @@ const getMetaFile = require('get-meta-file');
 const path = require('path');
 const program = require('commander');
 const util = require('util');
+const assertUsage = require('../lib/assertUsage');
+
+const usage = `
+usage: 
+       meta git clone <metaRepoUrl>
+       meta git clone <metaRepoUrl> --dir <foldername>
+       meta git clone <metaRepoUrl> --branch <branchname>
+       meta git clone <metaRepoUrl> --branch <branchname> --dir <foldername>
+       meta git clone <metaRepoUrl> --dir <foldername> --branch <branchname>
+       `;
 
 if ( ! process.argv[2] || process.argv[2] === '--help')
-  return console.log(`\n  usage:\n\n    meta git clone <metaRepoUrl>\n`);
+  return console.log(usage);
+if ( ! assertUsage('meta git clone', usage, { allow: /.*/ })) return console.log(usage);
+
 
 const repoUrl = process.argv[2] === 'blank' ?
                       process.argv[3] :
@@ -22,7 +34,7 @@ const branchNameIndex=process.argv.indexOf('--branch');
 const branch=branchNameIndex!==0?process.argv[branchNameIndex+1]:null;
 
 console.log(`meta git cloning into \'${repoUrl}\' at ${dirname}`);
-const mainCmd=branch===null?`git clone ${repoUrl} ${dirname}`: `git clone --single-branch -b ${branch} ${repoUrl} ${dirname}`;
+const mainCmd=branch===null?`git clone ${repoUrl} ${dirname}`: `git clone  -b ${branch} ${repoUrl} ${dirname}`;
 exec({ cmd: mainCmd , displayDir: dirname}, (err, result) => {
   if (err) throw err;
 
@@ -47,7 +59,7 @@ exec({ cmd: mainCmd , displayDir: dirname}, (err, result) => {
     folder = folders.pop()
 
     const gitUrl = projects[folder];
-	const cmd=branch===null?`git clone ${gitUrl} ${folder}`: `git clone --single-branch -b ${branch} ${gitUrl} ${folder}`;
+	const cmd=branch===null?`git clone ${gitUrl} ${folder}`: `git clone -b ${branch} ${gitUrl} ${folder}`;
 
     exec({ cmd: cmd, displayDir: path.join(newDir, folder) },  (err) => {
       if (err) throw err;

--- a/bin/meta-git-clone
+++ b/bin/meta-git-clone
@@ -34,7 +34,7 @@ const branchNameIndex=process.argv.indexOf('--branch');
 const branch=branchNameIndex!==0?process.argv[branchNameIndex+1]:null;
 
 console.log(`meta git cloning into \'${repoUrl}\' at ${dirname}`);
-const mainCmd=branch===null?`git clone ${repoUrl} ${dirname}`: `git clone  -b ${branch} ${repoUrl} ${dirname}`;
+const mainCmd=branch===null?`git clone ${repoUrl} ${dirname}`: `git clone --single-branch -b ${branch} ${repoUrl} ${dirname}`;
 exec({ cmd: mainCmd , displayDir: dirname}, (err, result) => {
   if (err) throw err;
 
@@ -59,7 +59,7 @@ exec({ cmd: mainCmd , displayDir: dirname}, (err, result) => {
     folder = folders.pop()
 
     const gitUrl = projects[folder];
-	const cmd=branch===null?`git clone ${gitUrl} ${folder}`: `git clone -b ${branch} ${gitUrl} ${folder}`;
+	const cmd=branch===null?`git clone ${gitUrl} ${folder}`: `git clone --single-branch -b ${branch} ${gitUrl} ${folder}`;
 
     exec({ cmd: cmd, displayDir: path.join(newDir, folder) },  (err) => {
       if (err) throw err;

--- a/bin/meta-git-clone
+++ b/bin/meta-git-clone
@@ -15,11 +15,15 @@ const repoUrl = process.argv[2] === 'blank' ?
                       process.argv[3] :
                       process.argv[2];
 
-const dirname = path.basename(repoUrl).replace('.git', '');
+const dirNameIndex=process.argv.indexOf('--dir');
+const dirname =dirNameIndex!==0?process.argv[dirNameIndex+1]:path.basename(repoUrl).replace('.git', '');
+
+const branchNameIndex=process.argv.indexOf('--branch');
+const branch=branchNameIndex!==0?process.argv[branchNameIndex+1]:null;
 
 console.log(`meta git cloning into \'${repoUrl}\' at ${dirname}`);
-
-exec({ cmd: `git clone ${repoUrl} ${dirname}`, displayDir: dirname }, (err, result) => {
+const mainCmd=branch===null?`git clone ${repoUrl} ${dirname}`: `git clone --single-branch -b ${branch} ${repoUrl} ${dirname}`;
+exec({ cmd: mainCmd , displayDir: dirname}, (err, result) => {
   if (err) throw err;
 
   const newDir = path.resolve(dirname);
@@ -43,8 +47,9 @@ exec({ cmd: `git clone ${repoUrl} ${dirname}`, displayDir: dirname }, (err, resu
     folder = folders.pop()
 
     const gitUrl = projects[folder];
+	const cmd=branch===null?`git clone ${gitUrl} ${folder}`: `git clone --single-branch -b ${branch} ${gitUrl} ${folder}`;
 
-    exec({ cmd: `git clone ${gitUrl} ${folder}`, displayDir: path.join(newDir, folder) },  (err) => {
+    exec({ cmd: cmd, displayDir: path.join(newDir, folder) },  (err) => {
       if (err) throw err;
 
       child();


### PR DESCRIPTION
Added additional optional parameters for meta git clone:

1. --branch: cloning specific branch, run the git with "--single-branch -b ${branch}"
2. --dir: folder to check out the main repo, folder names for child repos picked up from the .meta project file
example:
meta git clone "https://github.com/mateodelnorte/meta.git" --branch develop --dir foldername
Folder name can be "." also
Parameters are recognized with "process.argv.indexOf('paramname')" so the ordering is optional after the cloning url