### PR TITLE
Use HTTPS instead of SSH GitHub URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mateodelnorte/meta-git.git"
+    "url": "https://github.com/mateodelnorte/meta-git.git"
   },
   "keywords": [
     "git",


### PR DESCRIPTION
Unable to install meta behind a corporate proxy due to SSH GitHub URL.