### PR TITLE
feat: create single commit across all repositories

### DIFF
--- a/bin/meta-git-commit
+++ b/bin/meta-git-commit
@@ -26,8 +26,32 @@ function parseCommand(argv) {
     .join(' ');
 }
 
+function openEditor(command) {
+  const tmp = require('tmp');
+  const { execSync } = require('child_process');
+  const tmpFile = tmp.fileSync();
+  const cmd = `$EDITOR ${tmpFile.name}`;
+  execSync(cmd, {stdio: 'inherit'});
+  command = replaceFilenameInCommand(command, tmpFile.name);
+  metaLoop(command);
+}
+
+function shouldOpenEditor(command) {
+  return command.search(/[^-]-F\s*same(?:[^-]|$)/) != -1
+}
+
+function replaceFilenameInCommand(command, filename) {
+  return command.replace(/([^-]-F\s*)same([^-]|$)/, `$1${filename}$2`);
+}
+
 const command = `git commit ${parseCommand(process.argv.slice(2))}`;
 
 debug(`executing ${command}`);
 
-metaLoop(command);
+
+if (shouldOpenEditor(command)) {
+  openEditor(command)
+}
+else {
+  metaLoop(command);
+}


### PR DESCRIPTION
When a particular flag is sent to the commit operation (right now it's
"-F same", which needs to be changed to something better) open an
editor window using $EDITOR, and use that single commit message for
all subrepositories.

The mechanism is to use `git commit`'s -F option, but replace the
"same" value with the path to the temporary file opened in the editor.