### PR TITLE
Add grep command

### DIFF
--- a/bin/meta-git
+++ b/bin/meta-git
@@ -16,6 +16,7 @@ program
   .command('commit', 'Record changes to the repository')
   .command('diff', 'Show changes between commits, commit and working tree, etc')
   .command('fetch', 'Download objects and refs from another repository')
+  .command('grep', 'Print lines matching a pattern')
   .command('merge', 'Join two or more development histories together')
   .command('pull', 'Fetch from and integrate with another repository or a local branch')
   .command('push', 'Update remote refs along with associated objects')

--- a/bin/meta-git-grep
+++ b/bin/meta-git-grep
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const assertUsage = require('../lib/assertUsage');
+const debug = require('debug')('meta-git-grep');
+const metaLoop = require('meta-loop');
+
+const usage = `
+usage:
+       meta git grep [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]
+               [-v | --invert-match] [-h|-H] [--full-name]
+               [-E | --extended-regexp] [-G | --basic-regexp]
+               [-P | --perl-regexp]
+               [-F | --fixed-strings] [-n | --line-number] [--column]
+               [-l | --files-with-matches] [-L | --files-without-match]
+               [(-O | --open-files-in-pager) [<pager>]]
+               [-z | --null]
+               [ -o | --only-matching ] [-c | --count] [--all-match] [-q | --quiet]
+               [--max-depth <depth>] [--[no-]recursive]
+               [--color[=<when>] | --no-color]
+               [--break] [--heading] [-p | --show-function]
+               [-A <post-context>] [-B <pre-context>] [-C <context>]
+               [-W | --function-context]
+               [--threads <num>]
+               [-f <file>] [-e] <pattern>
+               [--and|--or|--not|(|)|-e <pattern>…]
+               [--recurse-submodules] [--parent-basename <basename>]
+               [ [--[no-]exclude-standard] [--cached | --no-index | --untracked] | <tree>…]
+               [--] [<pathspec>…]
+       `;
+
+if (process.argv[2] === '--help') return console.log(usage);
+
+if (!assertUsage('meta git grep', usage, { allow: /.*/ })) return console.log(usage);
+
+function parseCommand(argv) {
+  return argv
+    .map(arg => {
+      return arg.indexOf(' ') > 0 ? `"${arg}"` : arg;
+    })
+    .join(' ');
+}
+
+const command = `git grep ${parseCommand(process.argv.slice(2))}`;
+
+debug(`executing ${command}`);
+
+metaLoop(command);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "meta-git-commit": "./bin/meta-git-commit",
     "meta-git-diff": "./bin/meta-git-diff",
     "meta-git-fetch": "./bin/meta-git-fetch",
+    "meta-git-grep": "./bin/meta-git-grep",
     "meta-git-merge": "./bin/meta-git-merge",
     "meta-git-pull": "./bin/meta-git-pull",
     "meta-git-push": "./bin/meta-git-push",


### PR DESCRIPTION
This changeset adds support for running `meta git grep`.

When git fails to find a match in a repository, it returns exit code 1,
which `meta` interprets as a failure to run the command. This does cause
slightly misleading output, but does not prevent the command from
running completely across all repositories.