### PR TITLE
feat:  Allow empty folder to be git pulled or updated

### DIFF
--- a/lib/metaGitUpdate.js
+++ b/lib/metaGitUpdate.js
@@ -11,16 +11,15 @@ module.exports = (options = {}) => {
   
   // Filter out existing projects but allow empty directories
   const missing = Object.keys(meta.projects).filter(name => {
-    const fullPath = path.join(__dirname, name);
-    if (!fs.existsSync(fullPath)) {
-      return true;
+    if (fs.existsSync(name)) {
+      const stat = fs.lstatSync(name);
+      if (stat.isDirectory()) {
+        const files = fs.readdirSync(name);
+        return files.length === 0;
+      }
+      return false;
     }
-    const stat = fs.lstatSync(fullPath);
-    if (stat.isDirectory()) {
-      const files = fs.readdirSync(fullPath);
-      return files.length === 0;
-    }
-    return false;
+    return true;
   });
 
 

--- a/lib/metaGitUpdate.js
+++ b/lib/metaGitUpdate.js
@@ -8,11 +8,21 @@ const util = require('util');
 module.exports = (options = {}) => {
   const meta = getMetaFile({ confirmInMetaRepo: true, warn: false });
   if (!meta) return;
+  
+  // Filter out existing projects but allow empty directories
+  const missing = Object.keys(meta.projects).filter(name => {
+    const fullPath = path.join(__dirname, name);
+    if (!fs.existsSync(fullPath)) {
+      return true;
+    }
+    const stat = fs.lstatSync(fullPath);
+    if (stat.isDirectory()) {
+      const files = fs.readdirSync(fullPath);
+      return files.length === 0;
+    }
+    return false;
+  });
 
-  // Filter out existing projects.
-  const missing = Object.keys(meta.projects).filter(
-    name => !fs.existsSync(name)
-  );
 
   if (options.dryRun) {
     if (missing.length) {

--- a/lib/metaGitUpdate.js
+++ b/lib/metaGitUpdate.js
@@ -5,15 +5,44 @@ const getMetaFile = require('get-meta-file');
 const path = require('path');
 const util = require('util');
 
+
+function getSubmodulePaths(gitmodulesPath = '.gitmodules') {
+  try {
+    // Read the .gitmodules file
+    if(!fs.existsSync(gitmodulesPath)) {
+      return [];
+    }
+    const content = fs.readFileSync(gitmodulesPath, 'utf8');
+
+    // Parse the content using regular expressions
+    const submoduleRegex = /\[submodule "([^"]+)"\]\s*path = (.+)/g;
+    const submodulePaths = [];
+    let match;
+
+    while ((match = submoduleRegex.exec(content)) !== null) {
+      const path = match[2].trim();
+      submodulePaths.push(path);
+    }
+
+    return submodulePaths;
+  } catch (error) {
+    console.error('Error reading or parsing .gitmodules file:', error);
+    return [];
+  }
+}
+
+
 module.exports = (options = {}) => {
   const meta = getMetaFile({ confirmInMetaRepo: true, warn: false });
   if (!meta) return;
+
+  const submodulePaths = getSubmodulePaths();
   
-  // Filter out existing projects but allow empty directories
+  // Filter out existing projects but allow empty directories if they are also submodules
   const missing = Object.keys(meta.projects).filter(name => {
     if (fs.existsSync(name)) {
       const stat = fs.lstatSync(name);
-      if (stat.isDirectory()) {
+      if (stat.isDirectory() && submodulePaths.includes(name)) {
         const files = fs.readdirSync(name);
         return files.length === 0;
       }
@@ -21,7 +50,6 @@ module.exports = (options = {}) => {
     }
     return true;
   });
-
 
   if (options.dryRun) {
     if (missing.length) {


### PR DESCRIPTION
### Summary

**What kind of change does this PR introduce?** 
  * This PR adds additional flexibility to the project filtering logic in `metaGitUpdate.js` by allowing `meta git pull` and `meta git update` to work on empty folders.

**Reasoning**
  * When a .meta parent repo is updated via `git add .`, there's often a stored reference to the submodules.  This usually appears as a `subproject commit xxxxxxxxxxx` where a `git link` is stored to the relevant hashed commit of the other project.  This is common as a placeholder even when submodules are not being used, so that project architecture is apparent even without all submodules having been pulled.  But... the existence of these empty folders inhibits the `meta git update` from pulling down the sub repos.
  * By allowing empty folders:
     * developer on-boarding to meta is eased
     * no additional risk is introduced (since folders would be empty)
     * greater compatibility with submodule artifacts
     * main .meta repo architecture is explicit

**What is the current behavior?** 
  * The current implementation filters projects by checking if the project directories exist but does not account for empty directories.

**What is the new behavior?**
  * The new implementation filters out existing projects and allows for empty directories by:
    * Checking if the directory exists.
    * Verifying if the directory is empty before considering it missing.


**Does this PR introduce a breaking change?**
  * No breaking changes are introduced.

**Has Testing been included for this PR?**
  * No new tests added, but the existing tests should cover this change. 
